### PR TITLE
Only print notice if it contains a free subscription

### DIFF
--- a/classes/gateways/class-pb2b-normal-invoice-gateway.php
+++ b/classes/gateways/class-pb2b-normal-invoice-gateway.php
@@ -207,7 +207,7 @@ class PB2B_Normal_Invoice_Gateway extends PB2B_Factory_Gateway {
 			$create_payer_order = false;
 		}
 
-		if ( class_exists( 'WC_Subscriptions' ) && wcs_order_contains_subscription( $order ) && 0 >= $order->get_total() ) {
+		if ( 0 >= $order->get_total() ) {
 			$create_payer_order = false;
 		}
 
@@ -262,7 +262,9 @@ class PB2B_Normal_Invoice_Gateway extends PB2B_Factory_Gateway {
 			$order->add_order_note( __( 'Payment made with Payer', 'payer-b2b-for-woocommerce' ) );
 		} else {
 			$order->payment_complete();
-			$order->add_order_note( __( 'Free subscription order. No order created with Payer', 'payer-b2b-for-woocommerce' ) );
+			if ( class_exists( 'WC_Subscriptions' ) && wcs_order_contains_subscription( $order ) && 0 >= $order->get_total() ) {
+				$order->add_order_note( __( 'Free subscription order. No order created with Payer', 'payer-b2b-for-woocommerce' ) );
+			}
 		}
 		if ( ! $created_via_admin ) {
 			return array(

--- a/classes/gateways/class-pb2b-prepaid-invoice-gateway.php
+++ b/classes/gateways/class-pb2b-prepaid-invoice-gateway.php
@@ -224,9 +224,10 @@ class PB2B_Prepaid_Invoice_Gateway extends PB2B_Factory_Gateway {
 			$create_payer_order = false;
 		}
 
-		if ( class_exists( 'WC_Subscriptions' ) && wcs_order_contains_subscription( $order ) && 0 >= $order->get_total() ) {
+		if ( 0 >= $order->get_total() ) {
 			$create_payer_order = false;
 		}
+
 		// Check if we want to create an order.
 		if ( empty( $pno ) ) {
 			if ( $created_via_admin ) {
@@ -282,7 +283,10 @@ class PB2B_Prepaid_Invoice_Gateway extends PB2B_Factory_Gateway {
 			$order->add_order_note( __( 'Payment made with Payer', 'payer-b2b-for-woocommerce' ) );
 		} else {
 			$order->payment_complete();
-			$order->add_order_note( __( 'Free subscription order. No order created with Payer', 'payer-b2b-for-woocommerce' ) );
+
+			if ( class_exists( 'WC_Subscriptions' ) && wcs_order_contains_subscription( $order ) && 0 >= $order->get_total() ) {
+				$order->add_order_note( __( 'Free subscription order. No order created with Payer', 'payer-b2b-for-woocommerce' ) );
+			}
 		}
 		if ( ! $created_via_admin ) {
 			return array(


### PR DESCRIPTION
> The "free subscription" notice is printed on orders that are not subscription, but missing a Payer order ID.

Changes:
- Do not create a Payer order if the total amount is zero (this only applies to invoices).
- Only print the "free subscription" notice if the order contains a subscription, and  Payer order is _not_ created.

This was tested with subscription with and without 100% discounts, and with subscription renewals. The behavior is identical.